### PR TITLE
Create proxy socket for SSH_AUTH_SOCKET with adjusted permissions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN if [ "${TARGETARCH}" = "amd64" ]; then \
     echo "Unsupported architecture: ${TARGETARCH}}" &>2; return 1; \
   fi && \
   mkdir /ansible && mkdir /ansible-support && \
-  apt-get update && apt-get -y upgrade && apt-get -y install git gosu tar unzip rsync openssh-client curl gpg && rm -rf /var/lib/apt/lists/* && \
+  apt-get update && apt-get -y upgrade && apt-get -y install git gosu tar unzip rsync openssh-client curl gpg socat && rm -rf /var/lib/apt/lists/* && \
   echo "Downloading https://s3.amazonaws.com/session-manager-downloads/plugin/latest/${SESSION_MANAGER_TARGET}/session-manager-plugin.deb" && \
   curl -s "https://s3.amazonaws.com/session-manager-downloads/plugin/latest/${SESSION_MANAGER_TARGET}/session-manager-plugin.deb" -o "session-manager-plugin.deb" && \
   dpkg -i session-manager-plugin.deb && \

--- a/README.md
+++ b/README.md
@@ -90,3 +90,9 @@ docker run -it --rm \
 ## Ansible configuration via environment
 
 Any [Ansible environment variable](https://docs.ansible.com/ansible/latest/reference_appendices/config.html#ansible-configuration-settings) is passed through to Ansible unchanged. The exceptions are `ANSIBLE_PRIVATE_KEY_FILE` and `ANSIBLE_VAULT_PASSWORD_FILE`, which are rewritten by the entrypoint to point at copies owned by the `ansible` user.
+
+## Releasing
+
+```bash
+docker buildx build --platform linux/amd64,linux/arm64 -t hypoport/ansible:<version> --push .
+```

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,8 +1,17 @@
 #!/bin/sh
 
-# Ensure the SSH agent socket (e.g. from 1Password) is accessible by the ansible user
+# Fork the SSH agent socket so the ansible user can access it without relaxing
+# permissions on the original socket (e.g. from 1Password)
 if [ -S "${SSH_AUTH_SOCK}" ]; then
-  chmod 777 "${SSH_AUTH_SOCK}"
+
+  ANSIBLE_SSH_AUTH_SOCK="/tmp/ssh-auth-sock-ansible"
+  socat UNIX-LISTEN:"${ANSIBLE_SSH_AUTH_SOCK}",fork,reuseaddr UNIX-CONNECT:"${SSH_AUTH_SOCK}" &
+  SOCAT_PID=$!
+  trap 'kill ${SOCAT_PID} 2>/dev/null; rm -f ${ANSIBLE_SSH_AUTH_SOCK}' EXIT
+  while [ ! -S "${ANSIBLE_SSH_AUTH_SOCK}" ]; do sleep 1; done
+  chown ansible:ansible "${ANSIBLE_SSH_AUTH_SOCK}"
+  export SSH_AUTH_SOCK="${ANSIBLE_SSH_AUTH_SOCK}"
+
 fi
 
 PRIVATE_KEY_FILE=$(gosu ansible /home/ansible/venv/bin/ansible-config dump | grep DEFAULT_PRIVATE_KEY_FILE | cut -d = -f 2 | awk '{$1=$1};1')


### PR DESCRIPTION
Since Ansible runs as dedicated `ansible` user the ssh-agent socket oftentimes denies access to that user. To fix this, we simply create a proxy socket with proper permissions in the entrypoint, before running the Ansible command via `gosu ansible`.